### PR TITLE
ci: setup Android SDK for CI workflow

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -12,5 +12,13 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+      - uses: android-actions/setup-android@v2
+        with:
+          api-level: 34
+          build-tools: 34.0.0
+      - name: Set ANDROID_SDK_ROOT
+        run: echo "ANDROID_SDK_ROOT=$ANDROID_HOME" >> $GITHUB_ENV
+      - name: Accept Android SDK licenses
+        run: yes | sdkmanager --licenses
       - uses: gradle/gradle-build-action@v2
       - run: ./gradlew test


### PR DESCRIPTION
## Summary
- install Android SDK and accept licenses before Gradle tasks

## Testing
- `gradle test` *(fails: resource style/Theme.Material3.Light.NoActionBar not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abae59ac788324bcc905051ff48259